### PR TITLE
docs: add agentic guides and publish them with the npm package

- Add `guide/` index, usage, and integration documentation
- Ensure guides are included in the published package via `.npmignore` and `package.json` `files`
- Update `package-lock.json` to...

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,8 @@ yarn.lock
 vite.config.ts
 eslint.config.mjs
 README.md
+# Include AI integration guides
+!guide/
+!guide/*.md
+!guide/**/*.md
+

--- a/guide/index.md
+++ b/guide/index.md
@@ -1,0 +1,30 @@
+# @fjell/common-config - Agentic Guide
+
+## Purpose
+
+Shared build and lint configuration package for Fjell repositories.
+
+This guide is optimized for AI-assisted code generation and integration workflows.
+
+## Documentation
+
+- **[Usage Guide](./usage.md)** - API-oriented usage patterns and model-safe examples
+- **[Integration Guide](./integration.md)** - Architecture placement, composition rules, and implementation guidance
+
+## Key Capabilities
+
+- Publishes reusable ESLint and build configuration modules
+- Supports library, app, React, and CLI build profile composition
+- Reduces config drift across Fjell package repositories
+
+## Installation
+
+```bash
+npm install @fjell/common-config
+```
+
+## Public API Highlights
+
+- `eslint.config.mjs` baseline configuration
+- `esbuild.js`, `esbuild-library.js`, `esbuild-react.js`, and related presets
+- `index.js`, `library.js`, and `app.js` entry points

--- a/guide/integration.md
+++ b/guide/integration.md
@@ -1,0 +1,32 @@
+# Integration Guide
+
+Guide for integrating `@fjell/common-config` into larger Fjell-based systems.
+
+## Where It Fits
+
+Shared build and lint configuration package for Fjell repositories.
+
+## Recommended Integration Pattern
+
+- Import shared config modules directly from package entry files (no deep source imports)
+- Extend shared presets in-project rather than copying static config content
+- Version-lock this package with core Fjell repositories to minimize toolchain skew
+
+## System Composition Checklist
+
+- Define package boundaries: schema/types, transport, operations, adapters, and UI.
+- Keep contracts stable by sharing @fjell/types interfaces where applicable.
+- Centralize retries/timeouts/logging around infrastructure-facing operations.
+- Validate inputs at API boundaries before invoking persistence or provider layers.
+- Add contract and integration tests for every generated workflow.
+
+## Cross-Library Pairings
+
+- Pair with @fjell/types for shared contracts.
+- Pair with @fjell/validation for input and schema checks.
+- Pair with @fjell/logging for observability in integration flows.
+- Pair with storage/router/provider packages based on your runtime architecture.
+
+## Integration Example Shape
+
+Use this package behind an application service layer that exposes stable domain methods. Generated code should call those service methods, not raw infrastructure primitives, unless your architecture intentionally keeps infrastructure at the edge.

--- a/guide/usage.md
+++ b/guide/usage.md
@@ -1,0 +1,38 @@
+# Usage Guide
+
+Comprehensive usage guidance for `@fjell/common-config`.
+
+## Installation
+
+```bash
+npm install @fjell/common-config
+```
+
+## API Highlights
+
+- `eslint.config.mjs` baseline configuration
+- `esbuild.js`, `esbuild-library.js`, `esbuild-react.js`, and related presets
+- `index.js`, `library.js`, and `app.js` entry points
+
+## Quick Example
+
+```ts
+// eslint.config.mjs
+import fjellConfig from "@fjell/common-config/eslint.config.mjs";
+
+export default [...fjellConfig];
+```
+
+## Model Consumption Rules
+
+1. Import from the package root (`@fjell/common-config`) instead of deep-internal paths unless explicitly documented.
+2. Keep usage aligned with exported public symbols listed in this guide.
+3. Prefer explicit typing at package boundaries so generated code remains robust during upgrades.
+4. Keep error handling deterministic and map infrastructure failures into domain-level errors.
+5. Co-locate integration wrappers in your app so model-generated code has one canonical entry point.
+
+## Best Practices
+
+- Keep examples and abstractions consistent with existing Fjell package conventions.
+- Favor composable wrappers over one-off inline integration logic.
+- Add targeted tests around generated integration code paths.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fjell/common-config",
-  "version": "1.1.38",
+  "version": "1.1.39-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fjell/common-config",
-      "version": "1.1.38",
+      "version": "1.1.39-dev.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fjell/common-config",
-  "version": "1.1.38",
+  "version": "1.1.39-dev.0",
   "description": "Shared ESLint, Typescript and other configuration for all Fjell projects",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "esbuild-cli.js",
     "esbuild-multi-file.js",
     "eslint.config.mjs",
-    "README.md"
+    "README.md",
+    "guide"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Automated release PR.